### PR TITLE
Bump Dagger Hilt version to avoid permission issue

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -42,7 +42,7 @@ ext.versions = [
 
     // di
     daggerVersion           : '2.28',
-    daggerHiltAndroidVersion: '2.28-alpha',
+    daggerHiltAndroidVersion: '2.28.1-alpha',
     daggerHiltVersion       : '1.0.0-alpha01',
 
     // network


### PR DESCRIPTION
## Guidelines
Dagger Hilt `2.28-alpha` has a serious bug that adds `android.permission.READ_EXTERNAL_STORAGE`, `android.permission.READ_PHONE_STATE`, and `android.permission.WRITE_EXTERNAL_STORAGE` permissions to the merged AndroidManifest.
I was fixed on `2.28.1-alpha` ([related issue](https://github.com/google/dagger/issues/1864)).

### Types of changes
What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.