### PR TITLE
Migrate Sandwich to 1.2.0

### DIFF
--- a/app/src/main/java/com/skydoves/pokedex/di/NetworkModule.kt
+++ b/app/src/main/java/com/skydoves/pokedex/di/NetworkModule.kt
@@ -48,7 +48,7 @@ object NetworkModule {
       .client(okHttpClient)
       .baseUrl("https://pokeapi.co/api/v2/")
       .addConverterFactory(MoshiConverterFactory.create())
-      .addCallAdapterFactory(CoroutinesResponseCallAdapterFactory())
+      .addCallAdapterFactory(CoroutinesResponseCallAdapterFactory.create())
       .build()
   }
 

--- a/app/src/main/java/com/skydoves/pokedex/repository/DetailRepository.kt
+++ b/app/src/main/java/com/skydoves/pokedex/repository/DetailRepository.kt
@@ -27,7 +27,6 @@ import com.skydoves.sandwich.map
 import com.skydoves.sandwich.onError
 import com.skydoves.sandwich.onException
 import com.skydoves.sandwich.suspendOnSuccess
-import com.skydoves.whatif.whatIfNotNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -53,10 +52,8 @@ class DetailRepository @Inject constructor(
        */
       val response = pokedexClient.fetchPokemonInfo(name = name)
       response.suspendOnSuccess {
-        data.whatIfNotNull { response ->
-          pokemonInfoDao.insertPokemonInfo(response)
-          emit(response)
-        }
+        pokemonInfoDao.insertPokemonInfo(data)
+        emit(data)
       }
         // handles the case when the API request gets an error response.
         // e.g., internal server error.

--- a/app/src/main/java/com/skydoves/pokedex/repository/MainRepository.kt
+++ b/app/src/main/java/com/skydoves/pokedex/repository/MainRepository.kt
@@ -27,7 +27,6 @@ import com.skydoves.sandwich.map
 import com.skydoves.sandwich.onError
 import com.skydoves.sandwich.onException
 import com.skydoves.sandwich.suspendOnSuccess
-import com.skydoves.whatif.whatIfNotNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -55,12 +54,10 @@ class MainRepository @Inject constructor(
        */
       val response = pokedexClient.fetchPokemonList(page = page)
       response.suspendOnSuccess {
-        data.whatIfNotNull { response ->
-          pokemons = response.results
-          pokemons.forEach { pokemon -> pokemon.page = page }
-          pokemonDao.insertPokemonList(pokemons)
-          emit(pokemonDao.getAllPokemonList(page))
-        }
+        pokemons = data.results
+        pokemons.forEach { pokemon -> pokemon.page = page }
+        pokemonDao.insertPokemonList(pokemons)
+        emit(pokemonDao.getAllPokemonList(page))
       }
         // handles the case when the API request gets an error response.
         // e.g., internal server error.

--- a/app/src/test/java/com/skydoves/pokedex/network/ApiAbstract.kt
+++ b/app/src/test/java/com/skydoves/pokedex/network/ApiAbstract.kt
@@ -74,7 +74,7 @@ abstract class ApiAbstract<T> {
     return Retrofit.Builder()
       .baseUrl(mockWebServer.url("/"))
       .addConverterFactory(MoshiConverterFactory.create())
-      .addCallAdapterFactory(CoroutinesResponseCallAdapterFactory())
+      .addCallAdapterFactory(CoroutinesResponseCallAdapterFactory.create())
       .build()
       .create(clazz)
   }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,7 +51,7 @@ ext.versions = [
     // network
     retrofitVersion      : '2.9.0',
     okhttpVersion        : '4.9.0',
-    sandwichVersion      : '1.2.0-SNAPSHOT',
+    sandwichVersion      : '1.2.0',
 
     // moshi
     moshiVersion         : '1.11.0',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,7 +51,7 @@ ext.versions = [
     // network
     retrofitVersion      : '2.9.0',
     okhttpVersion        : '4.9.0',
-    sandwichVersion      : '1.0.9',
+    sandwichVersion      : '1.2.0-SNAPSHOT',
 
     // moshi
     moshiVersion         : '1.11.0',


### PR DESCRIPTION
## Guidelines
Migrate Sandwich to `1.2.0`.
Since the `1.2.0`, we don't need to check null-able the data property if the response is successful except the 204 and 205 code.

