### PR TITLE
[Edit] change pokemon image url

### DIFF
--- a/app/src/main/java/com/skydoves/pokedex/model/Pokemon.kt
+++ b/app/src/main/java/com/skydoves/pokedex/model/Pokemon.kt
@@ -34,6 +34,6 @@ data class Pokemon(
 
   fun getImageUrl(): String {
     val index = url.split("/".toRegex()).dropLast(1).last()
-    return "https://pokeres.bastionbot.org/images/pokemon/$index.png"
+    return "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/$index.png"
   }
 }


### PR DESCRIPTION
## Guidelines

### Types of changes
the former url "pokeres.bastionbot.org" didn't work and was not able to load the pokemon images so i changed the url to
"https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/$index.png" which works fine.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```