### PR TITLE
Made changes to Progressview component of Activity details

### DIFF
--- a/core-model/src/main/kotlin/com/skydoves/pokedex/core/model/PokemonInfo.kt
+++ b/core-model/src/main/kotlin/com/skydoves/pokedex/core/model/PokemonInfo.kt
@@ -39,11 +39,11 @@ data class PokemonInfo(
   fun getIdString(): String = String.format("#%03d", id)
   fun getWeightString(): String = String.format("%.1f KG", weight.toFloat() / 10)
   fun getHeightString(): String = String.format("%.1f M", height.toFloat() / 10)
-  fun getHpString(): String = "$hp/$maxHp"
-  fun getAttackString(): String = "$attack/$maxAttack"
-  fun getDefenseString(): String = "$defense/$maxDefense"
-  fun getSpeedString(): String = "$speed/$maxSpeed"
-  fun getExpString(): String = "$exp/$maxExp"
+  fun getHpString(): String = " $hp/$maxHp"
+  fun getAttackString(): String = " $attack/$maxAttack"
+  fun getDefenseString(): String = " $defense/$maxDefense"
+  fun getSpeedString(): String = " $speed/$maxSpeed"
+  fun getExpString(): String = " $exp/$maxExp"
 
   @JsonClass(generateAdapter = true)
   data class TypeResponse(


### PR DESCRIPTION
The progress value wasn't readable in progress view, so added space before the value.

Example : The value of SPD in Charizard card isn't readable.

![charizard_Before](https://user-images.githubusercontent.com/89389741/202726402-43e23243-4b8f-4229-b118-24010cf85f93.jpeg)
![charizard_After](https://user-images.githubusercontent.com/89389741/202726423-3d641ca3-d893-422e-8da8-8e68a5e004df.jpeg)
