### PR TITLE
Italian translation: fixed prefixes of base stats

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -19,9 +19,9 @@
   <string name="weight">Peso</string>
   <string name="height">Altezza</string>
   <string name="base_stats">Statistiche base</string>
-  <string name="hp">HP</string>
-  <string name="atk">ATK</string>
-  <string name="def">DEF</string>
-  <string name="spd">SPD</string>
-  <string name="exp">EXP</string>
+  <string name="hp">PS</string>
+  <string name="atk">ATT</string>
+  <string name="def">DIF</string>
+  <string name="spd">VEL</string>
+  <string name="exp">ESP</string>
 </resources>


### PR DESCRIPTION
## Guidelines
Hi, I noticed that in the activity of pokémon details, where we can se the base statistics, the Italian translation of prefixes for each statistic is not accurate. My fixes are:
- *PS* as *Punti salute*
- *ATT* as *Attacco*
- *DIF* as *Difesa*
- *VEL* as *Velocità*
- *ESP* as *Esperienza*

These labels are the same used in the [official Pokédex (Italian version)](https://www.pokemon.com/it/pokedex/bulbasaur).

### Types of changes
What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.