### PR TITLE
Remove unnecessary provide methode of PokedexClient

### DIFF
--- a/core-network/src/main/kotlin/com/skydoves/pokedex/core/network/di/NetworkModule.kt
+++ b/core-network/src/main/kotlin/com/skydoves/pokedex/core/network/di/NetworkModule.kt
@@ -17,7 +17,6 @@
 package com.skydoves.pokedex.core.network.di
 
 import com.skydoves.pokedex.core.network.interceptor.HttpRequestInterceptor
-import com.skydoves.pokedex.core.network.service.PokedexClient
 import com.skydoves.pokedex.core.network.service.PokedexService
 import com.skydoves.sandwich.adapters.ApiResponseCallAdapterFactory
 import dagger.Module
@@ -56,11 +55,5 @@ internal object NetworkModule {
   @Singleton
   fun providePokedexService(retrofit: Retrofit): PokedexService {
     return retrofit.create(PokedexService::class.java)
-  }
-
-  @Provides
-  @Singleton
-  fun providePokedexClient(pokedexService: PokedexService): PokedexClient {
-    return PokedexClient(pokedexService)
   }
 }


### PR DESCRIPTION
### Types of changes

Remove unnecessary provide methode of PokedexClient in hilt NetworkModule because this class is not a third party class, his constructor annotated with @Inject define how to instantiate it.

This is my first contribution in open source projects, eagerly waiting for your evaluation.