### PR TITLE
Change repositories order in build.gradle.kts file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,8 +21,8 @@ plugins {
 
 buildscript {
   repositories {
-    google()
     mavenCentral()
+    google()
     gradlePluginPortal()
   }
 


### PR DESCRIPTION
Change the order of the build script repositories in order to reduce the failed requests for download dependencies and faster sync and builds especially for the first time.
At this point, we have 71 failed requests on Google and 5 on MavenCentral.