### PR TITLE
Migrate KotlinCompile configuration to compilerOptions DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@
 // * limitations under the License.
 // */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.android.library) apply false
@@ -78,11 +80,13 @@ subprojects {
   }
 
   tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions.jvmTarget = bytecodeVersion.toString()
-    kotlinOptions.freeCompilerArgs += listOf(
-      "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-      "-opt-in=kotlin.time.ExperimentalTime",
-    )
+    compilerOptions {
+      jvmTarget.set(JvmTarget.fromTarget(bytecodeVersion.toString()))
+      freeCompilerArgs.addAll(
+        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+        "-opt-in=kotlin.time.ExperimentalTime",
+      )
+    }
   }
 
   extensions.configure<com.diffplug.gradle.spotless.SpotlessExtension> {


### PR DESCRIPTION
# Pull Request: Migrate from `kotlinOptions` to `compilerOptions` DSL

## Guidelines
This PR migrates from the deprecated `kotlinOptions` block to the new `compilerOptions` DSL for KotlinCompile tasks.  
The change removes deprecation warnings and aligns the project with the latest Gradle/Kotlin best practices, ensuring forward compatibility.  

## Types of changes
- [x] Refactor (non-breaking change that improves build configuration)  

## Related Issues
- Fixes part of [#324](https://github.com/skydoves/Pokedex/issues/324) (Kotlin 2.2.10 build failures).  
  While this PR does not resolve the Kotlin 2.2.10 incompatibility itself, it ensures the project is ready for future upgrades by removing usage of deprecated APIs.  

## Preparing a pull request for review
- [x] Code formatted using `./gradlew spotlessApply`  
- Verified that the project builds and syncs successfully after migration.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.
- Chores
  - Updated internal build configuration for Kotlin compiler settings across modules to a modern DSL for greater consistency and maintainability.
  - Preserved existing experimental feature opt-ins; no behavioral or API changes.
  - No impact on performance or compatibility; builds remain reproducible. This is a behind-the-scenes change and requires no action from users or integrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->